### PR TITLE
EZEE-1434: Check user content create permissions

### DIFF
--- a/bundle/Resources/public/css/themes/views/upload-form.css
+++ b/bundle/Resources/public/css/themes/views/upload-form.css
@@ -24,6 +24,26 @@
     font-size: .75rem;
 }
 
+.ez-view-mfuuploadformview .mfu-form__container:after {
+    z-index: -1;
+    background: rgba(0,0,0,0);
+    transition: .3s background cubic-bezier(.25,.8,.25,1);
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-radius: .5rem;
+    z-index: 100;
+}
+
+.ez-view-mfuuploadformview .mfu-form__container.mfu-form--inactive:after {
+    background: rgba(0,0,0,.3);
+    cursor: not-allowed;
+}
+
 .ez-platformui-app .ez-view-mfuuploadformview .mfu-form___btn--select-files {
     background: #fafafa;
     color: #3fb499;

--- a/bundle/Resources/public/templates/upload-form.hbt
+++ b/bundle/Resources/public/templates/upload-form.hbt
@@ -6,7 +6,7 @@
         </symbol>
     </defs>
 </svg>
-<div class="mfu-form__container">
+<div class="mfu-form__container mfu-form--inactive">
     <h3 class="mfu-form__call-to-action">Drag your files here</h3>
     <label class="mfu-form__other-action" for="mfu-files">or if you prefer</label>
     <button class="mfu-form___btn--select-files">


### PR DESCRIPTION
https://jira.ez.no/browse/EZEE-1434

Requires extensive testing.

When a user is allowed to create content of specific type using multi file upload form, then it will be enabled. By default the form is disabled.
