### PR TITLE
EZEE-1451: Simplify mime type configuration

### DIFF
--- a/bundle/ApplicationConfig/Providers/ContentTypeMappings.php
+++ b/bundle/ApplicationConfig/Providers/ContentTypeMappings.php
@@ -61,30 +61,30 @@ class ContentTypeMappings
                 'mappings' => [],
             ];
 
-            foreach ($locationConfiguration['mappings'] as $mapping) {
-                $structure['locationMappings'][$locationIdentifier]['mappings'][] = $this->buildMappingStructure($mapping);
+            foreach ($locationConfiguration['mappings'] as $mappingGroup) {
+                $structure['locationMappings'][$locationIdentifier]['mappings'][] = $this->buildMappingGroupStructure($mappingGroup);
             }
         }
 
-        foreach ($this->defaultMappings as $mapping) {
-            $structure['defaultMappings'][] = $this->buildMappingStructure($mapping);
+        foreach ($this->defaultMappings as $mappingGroup) {
+            $structure['defaultMappings'][] = $this->buildMappingGroupStructure($mappingGroup);
         }
 
         return $structure;
     }
 
     /**
-     * @param array $mapping
+     * @param array $mappingGroup
      *
      * @return array
      */
-    private function buildMappingStructure(array $mapping)
+    private function buildMappingGroupStructure(array $mappingGroup)
     {
         return [
-            'mimeType' => $mapping['mime_type'],
-            'contentTypeIdentifier' => $mapping['content_type_identifier'],
-            'contentFieldIdentifier' => $mapping['content_field_identifier'],
-            'nameFieldIdentifier' => $mapping['name_field_identifier'],
+            'mimeTypes' => $mappingGroup['mime_types'],
+            'contentTypeIdentifier' => $mappingGroup['content_type_identifier'],
+            'contentFieldIdentifier' => $mappingGroup['content_field_identifier'],
+            'nameFieldIdentifier' => $mappingGroup['name_field_identifier'],
         ];
     }
 

--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -34,7 +34,26 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->children()
                 ->arrayNode('location_mappings')
-                    ->info('Let\'s you assign mappings bound to location')
+                    ->info('Let\'s you assign mappings bound to a location')
+                    ->example([
+                        [
+                            'content_type_identifier' => 'gallery',
+                            'mime_type_filter' => [
+                                'image/*',
+                            ],
+                            'mappings' => [
+                                [
+                                    'mime_types' => [
+                                        'image/jpeg',
+                                        'image/png',
+                                    ],
+                                    'content_type_identifier' => 'image',
+                                    'content_field_identifier' => 'image',
+                                    'name_field_identifier' => 'name',
+                                ],
+                            ],
+                        ],
+                    ])
                     ->prototype('array')
                         ->children()
                             ->scalarNode('content_type_identifier')
@@ -51,9 +70,10 @@ class Configuration implements ConfigurationInterface
                                 ->cannotBeEmpty()
                                 ->prototype('array')
                                     ->children()
-                                        ->scalarNode('mime_type')
+                                        ->arrayNode('mime_types')
                                             ->isRequired()
                                             ->cannotBeEmpty()
+                                            ->prototype('scalar')->end()
                                         ->end()
                                         ->scalarNode('content_type_identifier')
                                             ->isRequired()
@@ -77,9 +97,10 @@ class Configuration implements ConfigurationInterface
                     ->info('These mappings are used as a fallback in case there are no entries under `locations` key')
                     ->prototype('array')
                         ->children()
-                            ->scalarNode('mime_type')
+                            ->arrayNode('mime_types')
                                 ->isRequired()
                                 ->cannotBeEmpty()
+                                ->prototype('scalar')->end()
                             ->end()
                             ->scalarNode('content_type_identifier')
                                 ->isRequired()
@@ -98,22 +119,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('fallback_content_type')
                     ->info('This content type will be used for files with no mime type mapping')
-                    ->validate()
-                        ->always(function ($v) {
-                            if (
-                                empty($v['content_type_identifier'])
-                                || empty($v['content_field_identifier'])
-                            ) {
-                                $v = [
-                                    'content_type_identifier' => null,
-                                    'content_field_identifier' => null,
-                                    'name_field_identifier' => null,
-                                ];
-                            }
-
-                            return $v;
-                        })
-                    ->end()
                     ->children()
                         ->scalarNode('content_type_identifier')
                             ->defaultNull()
@@ -122,7 +127,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultNull()
                         ->end()
                         ->scalarNode('name_field_identifier')
-                            ->defaultValue('name') // should work for most content types
+                            ->defaultNull()
                         ->end()
                     ->end()
                 ->end()

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -1,29 +1,37 @@
 parameters:
-    ez_systems.multifile_upload.rest.path_prefix: /api/multifileupload/v1
-
     ez_systems.multifile_upload.location_mappings: []
 
     ez_systems.multifile_upload.default_mappings:
-        - { mime_type: image/jpeg, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/jpg, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/pjpeg, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/pjpg, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/pjpg, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/png, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/bmp, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/gif, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/tiff, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/x-icon, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/svg+xml, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: image/webp, content_type_identifier: image, content_field_identifier: image }
-        - { mime_type: application/msword, content_type_identifier: file, content_field_identifier: file }
-        - { mime_type: application/vnd.openxmlformats-officedocument.wordprocessingml.document, content_type_identifier: file, content_field_identifier: file }
-        - { mime_type: application/vnd.ms-excel, content_type_identifier: file, content_field_identifier: file }
-        - { mime_type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, content_type_identifier: file, content_field_identifier: file }
-        - { mime_type: application/vnd.ms-powerpoint, content_type_identifier: file, content_field_identifier: file }
-        - { mime_type: application/vnd.openxmlformats-officedocument.presentationml.presentation, content_type_identifier: file, content_field_identifier: file }
-        - { mime_type: application/pdf, content_type_identifier: file, content_field_identifier: file }
+        - # image
+          mime_types:
+            - image/jpeg
+            - image/jpg
+            - image/pjpeg
+            - image/pjpg
+            - image/png
+            - image/bmp
+            - image/gif
+            - image/tiff
+            - image/x-icon
+            - image/webp
+          content_type_identifier: image
+          content_field_identifier: image
+          name_field_identifier: name
+        - # file
+          mime_types:
+            - image/svg+xml
+            - application/msword
+            - application/vnd.openxmlformats-officedocument.wordprocessingml.document
+            - application/vnd.ms-excel
+            - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+            - application/vnd.ms-powerpoint
+            - application/vnd.openxmlformats-officedocument.presentationml.presentation
+            - application/pdf
+          content_type_identifier: file
+          content_field_identifier: file
+          name_field_identifier: name
 
     ez_systems.multifile_upload.fallback_content_type:
         content_type_identifier: file
         content_field_identifier: file
+        name_field_identifier: name

--- a/bundle/Resources/public/css/layouts/views/upload-popup.css
+++ b/bundle/Resources/public/css/layouts/views/upload-popup.css
@@ -55,12 +55,13 @@
 }
 
 .mfu-popup-opened .mfu-popup-overlay {
-    position: absolute;
+    position: fixed;
     top: 0;
     bottom: 0;
     left: 0;
     right: 0;
     z-index: 10000;
+    transform: translate3d(0,0,0);
 }
 
 .ez-view-mfuuploadpopupview.mfu-popup--hidden {

--- a/bundle/Resources/public/js/plugins/mfu-fileupload-plugin.js
+++ b/bundle/Resources/public/js/plugins/mfu-fileupload-plugin.js
@@ -277,13 +277,13 @@ YUI.add('mfu-fileupload-plugin', function (Y) {
             const locationIdentifier = this.get('host').get('contentType').get('identifier');
             const locationMappings = this.get('contentTypeByLocationMappings');
             const mappedLocation = locationMappings.find(item => item.contentTypeIdentifier === locationIdentifier);
-            const uniqueIdentifiers = mappedLocation ?
-                [...new Set(mappedLocation.mappings.map(item => item.contentTypeIdentifier))] :
-                [];
-            let promises = [this._loadContentTypeByIdentifier(defaultContentTypeIdentifier)];
+            const uniqueIdentifiers = mappedLocation ? [...new Set(mappedLocation.mappings.map(item => item.contentTypeIdentifier))] : [];
+            let promises = [];
 
             if (uniqueIdentifiers.length) {
                 promises = uniqueIdentifiers.map(identifier => this._loadContentTypeByIdentifier(identifier));
+            } else {
+                promises = [this._loadContentTypeByIdentifier(defaultContentTypeIdentifier)];
             }
 
             Promise.all(promises)
@@ -498,7 +498,7 @@ YUI.add('mfu-fileupload-plugin', function (Y) {
                 return true;
             }
 
-            return !!locationMapping.mappings.find(item => item.mimeType === file.type);
+            return !!this._findMimeTypeMapping(locationMapping.mappings, file);
         },
 
         /**
@@ -538,9 +538,9 @@ YUI.add('mfu-fileupload-plugin', function (Y) {
          * @protected
          * @param mappings {Array} list of mappings
          * @param file {File} File object
-         * @return {Boolean}
+         * @return {Object}
          */
-        _findMimeTypeMapping: (mappings, file) => mappings.find(item => item.mimeType === file.type),
+        _findMimeTypeMapping: (mappings, file) => mappings.find(item => item.mimeTypes.find(type => type === file.type)),
 
         /**
          * Resolves/rejects a promise

--- a/tests/bundle/ApplicationConfig/Providers/ContentTypeMappingsTest.php
+++ b/tests/bundle/ApplicationConfig/Providers/ContentTypeMappingsTest.php
@@ -20,46 +20,48 @@ class ContentTypeMappingsTest extends \PHPUnit_Framework_TestCase
                 ],
                 'mappings' => [
                     [
-                        'mime_type' => 'application/msword',
-                        'content_type_identifier' => 'file',
-                        'content_field_identifier' => 'file',
-                    ],
-                    [
-                        'mime_type' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                        'content_type_identifier' => 'file',
-                        'content_field_identifier' => 'file',
+                        'mime_types' => [
+                            'image/jpeg',
+                            'image/png',
+                        ],
+                        'content_type_identifier' => 'image',
+                        'content_field_identifier' => 'image',
+                        'name_field_identifier' => 'name',
                     ],
                 ],
             ],
             [
                 'content_type_identifier' => 3,
                 'mime_type_filter' => [
-                    'video/*',
+                    'application/msword',
                 ],
                 'mappings' => [
                     [
-                        'mime_type' => 'application/msword',
+                        'mime_types' => [
+                            'application/msword'
+                        ],
                         'content_type_identifier' => 'file',
                         'content_field_identifier' => 'file',
+                        'name_field_identifier' => 'name',
                     ],
                 ],
             ],
         ];
         $defaultMappings = [
             [
-                'mime_type' => 'application/msword',
+                'mime_types' => [
+                    'application/msword',
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                ],
                 'content_type_identifier' => 'file',
                 'content_field_identifier' => 'file',
-            ],
-            [
-                'mime_type' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                'content_type_identifier' => 'file',
-                'content_field_identifier' => 'file',
+                'name_field_identifier' => 'name',
             ],
         ];
         $fallbackContentType = [
             'content_type_identifier' => 'file',
             'content_field_identifier' => 'file',
+            'name_field_identifier' => 'name',
         ];
         $maxFileSize = 64000000;
 
@@ -80,51 +82,53 @@ class ContentTypeMappingsTest extends \PHPUnit_Framework_TestCase
                     ],
                     'mappings' => [
                         [
-                            'mimeType' => 'application/msword',
-                            'contentTypeIdentifier' => 'file',
-                            'contentFieldIdentifier' => 'file',
-                        ],
-                        [
-                            'mimeType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                            'contentTypeIdentifier' => 'file',
-                            'contentFieldIdentifier' => 'file',
+                            'mimeTypes' => [
+                                'image/jpeg',
+                                'image/png',
+                            ],
+                            'contentTypeIdentifier' => 'image',
+                            'contentFieldIdentifier' => 'image',
+                            'nameFieldIdentifier' => 'name',
                         ],
                     ],
                 ],
                 [
                     'contentTypeIdentifier' => 3,
                     'mimeTypeFilter' => [
-                        'video/*',
+                        'application/msword',
                     ],
                     'mappings' => [
                         [
-                            'mimeType' => 'application/msword',
+                            'mimeTypes' => [
+                                'application/msword',
+                            ],
                             'contentTypeIdentifier' => 'file',
                             'contentFieldIdentifier' => 'file',
+                            'nameFieldIdentifier' => 'name',
                         ],
                     ],
                 ],
             ],
             'defaultMappings' => [
                 [
-                    'mimeType' => 'application/msword',
+                    'mimeTypes' => [
+                        'application/msword',
+                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    ],
                     'contentTypeIdentifier' => 'file',
                     'contentFieldIdentifier' => 'file',
-                ],
-                [
-                    'mimeType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                    'contentTypeIdentifier' => 'file',
-                    'contentFieldIdentifier' => 'file',
+                    'nameFieldIdentifier' => 'name',
                 ],
             ],
             'fallbackContentType' => [
                 'contentTypeIdentifier' => 'file',
                 'contentFieldIdentifier' => 'file',
+                'nameFieldIdentifier' => 'name',
             ],
             'maxFileSize' => 64000000,
         ];
 
-        $this->assertArraySubset($contentTypeMappingsConfig->getConfig(), $expectedArray);
+        $this->assertArraySubset($expectedArray, $contentTypeMappingsConfig->getConfig());
     }
 
     public function testGetConfigWithEmptyValues()
@@ -134,6 +138,7 @@ class ContentTypeMappingsTest extends \PHPUnit_Framework_TestCase
         $fallbackContentType = [
             'content_type_identifier' => null,
             'content_field_identifier' => null,
+            'name_field_identifier' => null,
         ];
         $maxFileSize = null;
 
@@ -145,6 +150,7 @@ class ContentTypeMappingsTest extends \PHPUnit_Framework_TestCase
             'fallbackContentType' => [
                 'contentTypeIdentifier' => null,
                 'contentFieldIdentifier' => null,
+                'nameFieldIdentifier' => null,
             ],
             'maxFileSize' => null,
         ];


### PR DESCRIPTION
**JIRA: https://jira.ez.no/browse/EZEE-1451**

**This ticket is duplicate of #16 because previous one seems to be broken due to repository name change.**

Mime types are now put into groups with common content type:

```yaml
ez_systems_multi_file_upload:
    location_mappings:
        -   # gallery
            content_type_identifier: gallery
            mime_type_filter:
                - video/*
                - image/*
            mappings:
                -   # images
                    mime_types:
                        - image/jpeg
                        - image/jpg
                        - image/pjpeg
                        - image/pjpg
                        - image/png
                        - image/bmp
                        - image/gif
                        - image/tiff
                        - image/x-icon
                        - image/webp
                    content_type_identifier: image
                    content_field_identifier: image
                    name_field_identifier: name
                -   # videos
                    mime_types:
                        - video/avi
                        - video/mpeg
                        - video/quicktime
                        - video/mp4
                        - video/webm
                        - video/3gpp
                        - video/x-msvideo
                        - video/ogg
                    content_type_identifier: video
                    content_field_identifier: file
                    name_field_identifier: name
                -   # .svg files are not supported by Image content type atm
                    mime_types:
                        - image/svg+xml
                    content_type_identifier: file
                    content_field_identifier: file
                    name_field_identifier: name
        -   # folder
            content_type_identifier: folder
            mappings:
                -   # files
                    mime_types:
                        - application/msword
                        - application/vnd.openxmlformats-officedocument.wordprocessingml.document
                        - application/vnd.ms-excel
                        - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
                        - application/vnd.ms-powerpoint
                        - application/vnd.openxmlformats-officedocument.presentationml.presentation
                        - application/pdf
                    content_type_identifier: file
                    content_field_identifier: file
                    name_field_identifier: name

    default_mappings:
        -   # image
            mime_types:
                - image/jpeg
                - image/jpg
                - image/pjpeg
                - image/pjpg
                - image/png
                - image/bmp
                - image/gif
                - image/tiff
                - image/x-icon
                - image/webp
            content_type_identifier: image
            content_field_identifier: image
            name_field_identifier: name
        -   # file
            mime_types:
                - image/svg+xml
                - application/msword
                - application/vnd.openxmlformats-officedocument.wordprocessingml.document
                - application/vnd.ms-excel
                - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
                - application/vnd.ms-powerpoint
                - application/vnd.openxmlformats-officedocument.presentationml.presentation
                - application/pdf
            content_type_identifier: file
            content_field_identifier: file
            name_field_identifier: name

    fallback_content_type:
        content_type_identifier: file
        content_field_identifier: file
        name_field_identifier: name
```

# TODO
- [x] reflect changes on the frontend (@sunpietro)