### PR TITLE
[Symfony 3.x] Remove ->cannotBeEmpty() call on integerNode

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -133,7 +133,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->integerNode('max_file_size')
                     ->defaultValue(64000000) // 64MB
-                    ->cannotBeEmpty()
                 ->end()
             ->end()
         ;


### PR DESCRIPTION
`cannotBeEmpty()` cannot be used on integer nodes in Symfony 3.2 and produces the following exception:

```
  [Symfony\Component\Config\Definition\Exception\InvalidDefinitionException]
  ->cannotBeEmpty() is not applicable to NumericNodeDefinition.
```