### PR TITLE
 EZP-27439: Improve Multi File Upload loading time

### DIFF
--- a/bundle/Controller/RestController.php
+++ b/bundle/Controller/RestController.php
@@ -41,21 +41,19 @@ class RestController
     }
 
     /**
-     * @param int $contentTypeId
      * @param int $parentLocationId
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return \EzSystems\MultiFileUpload\API\Repository\Values\PermissionReport
      */
-    public function checkPermission($contentTypeId, $parentLocationId, Request $request)
+    public function checkPermission($parentLocationId, Request $request)
     {
         if (!$request->isXmlHttpRequest()) {
             throw new BadRequestHttpException('The request is not an AJAX request');
         }
 
-        $contentType = $this->contentTypeService->loadContentType($contentTypeId);
         $parentLocation = $this->locationService->loadLocation($parentLocationId);
 
-        return $this->permissionReportService->canUserCreateContent($contentType, $parentLocation);
+        return $this->permissionReportService->canUserCreateContent($parentLocation);
     }
 }

--- a/bundle/Resources/config/routing.yml
+++ b/bundle/Resources/config/routing.yml
@@ -1,8 +1,7 @@
 ez_systems.multifile_upload.controller.rest.check_permission:
     methods: [GET]
-    path: /multifileupload/v1/check-permission/{parentLocationId}/{contentTypeId}
+    path: /multifileupload/v1/check-permission/{parentLocationId}
     requirements:
         parentLocationId: '\d+'
-        contentTypeId: '\d+'
     defaults:
         _controller: ez_systems.multifile_upload.controller.rest:checkPermission

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -21,7 +21,11 @@ services:
         arguments:
             - '@ez_systems.multifile_upload.service.permission_resolver'
             - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.content_type'
             - '@ezpublish.api.service.location'
+            - '%ez_systems.multifile_upload.location_mappings%'
+            - '%ez_systems.multifile_upload.default_mappings%'
+            - '%ez_systems.multifile_upload.fallback_content_type%'
 
     ez_systems.multifile_upload.controller.rest:
         class: '%ez_systems.multifile_upload.controller.rest.class%'
@@ -30,7 +34,7 @@ services:
             - '@ezpublish.api.service.location'
             - '@ez_systems.multifile_upload.service.permission_report'
 
-    # todo: remove once kernel bundle exposes PermissionResolver as a DI service
+    # todo: remove once kernel exposes PermissionResolver as a DI service
     ez_systems.multifile_upload.service.permission_resolver:
         class: '%ez_systems.multifile_upload.service.permission_resolver.class%'
         factory: ['@ezpublish.api.inner_repository', 'getPermissionResolver']

--- a/bundle/Resources/public/js/views/mfu-uploadform-view.js
+++ b/bundle/Resources/public/js/views/mfu-uploadform-view.js
@@ -80,6 +80,11 @@ YUI.add('mfu-uploadform-view', function (Y) {
                 return;
             }
 
+            if (this.get('checkPermissionPrevented')) {
+                this._setFormActiveState(true);
+                return;
+            }
+
             /**
              * Checks for content create permissions for a logged in user.
              * Listened by {{#crossLink "mfu.Plugin.FileUploadService"}}mfu.Plugin.FileUploadService{{/crossLink}}
@@ -359,6 +364,19 @@ YUI.add('mfu-uploadform-view', function (Y) {
             checkPermissionsErrorText: {
                 valueFn: () => Y.eZ.trans('file.upload.permissions.check.error', {}, 'uploadform'),
                 readOnly: true,
+            },
+
+            /**
+             * Flag indicating if the permissons check should be ommited.
+             * If set to truthy value user is allowed to create content.
+             *
+             * @attribute checkPermissionPrevented
+             * @type {Boolean}
+             * @writeOnce 'initOnly'
+             */
+            checkPermissionPrevented: {
+                value: false,
+                writeOnce: 'initOnly',
             },
         }
     });

--- a/bundle/Resources/public/js/views/mfu-uploadpopup-view.js
+++ b/bundle/Resources/public/js/views/mfu-uploadpopup-view.js
@@ -354,7 +354,8 @@ YUI.add('mfu-uploadpopup-view', function (Y) {
                 valueFn: function () {
                     return new Y.mfu.UploadFormView({
                         bubbleTargets: this,
-                        onDropCallback: this._updateUploadedFilesList.bind(this)
+                        onDropCallback: this._updateUploadedFilesList.bind(this),
+                        checkPermissionPrevented: true
                     });
                 },
                 readOnly: true,

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "0.2.x-dev"
         }
     }
 }

--- a/lib/API/Repository/PermissionReportServiceInterface.php
+++ b/lib/API/Repository/PermissionReportServiceInterface.php
@@ -17,11 +17,10 @@ interface PermissionReportServiceInterface
     /**
      * Returns PermissionReport regarding content:create permission for the contentType in location.
      *
-     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      * @param \eZ\Publish\API\Repository\Values\Content\Location $parentLocation
      * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
      *
      * @return \EzSystems\MultiFileUpload\API\Repository\Values\PermissionReport
      */
-    public function canUserCreateContent(ContentType $contentType, Location $parentLocation, UserReference $userReference = null);
+    public function canUserCreateContent(Location $parentLocation, UserReference $userReference = null);
 }

--- a/lib/API/Repository/Values/PermissionReport.php
+++ b/lib/API/Repository/Values/PermissionReport.php
@@ -10,9 +10,6 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 class PermissionReport extends ValueObject
 {
     /** @var int */
-    public $contentTypeId;
-
-    /** @var int */
     public $parentLocationId;
 
     /** @var string */
@@ -21,6 +18,6 @@ class PermissionReport extends ValueObject
     /** @var string */
     public $function;
 
-    /** @var bool */
-    public $allowed;
+    /** @var string[] */
+    public $allowedContentTypes;
 }

--- a/lib/Core/REST/Server/Output/ValueObjectVisitor/PermissionReport.php
+++ b/lib/Core/REST/Server/Output/ValueObjectVisitor/PermissionReport.php
@@ -25,17 +25,18 @@ class PermissionReport extends ValueObjectVisitor
         $generator->startValueElement('parentLocationId', $data->parentLocationId);
         $generator->endValueElement('parentLocationId');
 
-        $generator->startValueElement('contentTypeId', $data->contentTypeId);
-        $generator->endValueElement('contentTypeId');
-
         $generator->startValueElement('module', $data->module);
         $generator->endValueElement('module');
 
         $generator->startValueElement('function', $data->function);
         $generator->endValueElement('function');
 
-        $generator->startValueElement('allowed', $data->allowed);
-        $generator->endValueElement('allowed');
+        $generator->startList('allowedContentTypes');
+        foreach ($data->allowedContentTypes as $contentTypeIdentifier) {
+            $generator->startValueElement('allowedContentTypes', $contentTypeIdentifier);
+            $generator->endValueElement('allowedContentTypes');
+        }
+        $generator->endList('allowedContentTypes');
 
         $generator->endObjectElement('PermissionReport');
     }

--- a/lib/Core/Repository/PermissionReportService.php
+++ b/lib/Core/Repository/PermissionReportService.php
@@ -6,10 +6,10 @@
 namespace EzSystems\MultiFileUpload\Core\Repository;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\Content\Location;
-use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\UserReference;
 use EzSystems\MultiFileUpload\API\Repository\PermissionReportServiceInterface;
 use EzSystems\MultiFileUpload\API\Repository\Values\PermissionReport;
@@ -25,59 +25,125 @@ class PermissionReportService implements PermissionReportServiceInterface
     /** @var \eZ\Publish\API\Repository\ContentService */
     protected $contentService;
 
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    protected $contentTypeService;
+
     /** @var \eZ\Publish\API\Repository\LocationService */
     protected $locationService;
+
+    /** @var array */
+    protected $locationMappings = [];
+
+    /** @var array */
+    protected $defaultMappings = [];
+
+    /** @var array */
+    protected $fallbackContentType = [];
 
     /**
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
      * @param \eZ\Publish\API\Repository\LocationService $locationService
+     * @param array $locationMappings
+     * @param array $defaultMappings
+     * @param array $fallbackContentType
      */
     public function __construct(
         PermissionResolver $permissionResolver,
         ContentService $contentService,
-        LocationService $locationService
+        ContentTypeService $contentTypeService,
+        LocationService $locationService,
+        array $locationMappings,
+        array $defaultMappings,
+        array $fallbackContentType
     ) {
         $this->permissionResolver = $permissionResolver;
         $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
         $this->locationService = $locationService;
+        $this->locationMappings = $locationMappings;
+        $this->defaultMappings = $defaultMappings;
+        $this->fallbackContentType = $fallbackContentType;
     }
 
     /**
-     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      * @param \eZ\Publish\API\Repository\Values\Content\Location $parentLocation
      * @param \eZ\Publish\API\Repository\Values\User\UserReference|null $userReference
      *
      * @return \EzSystems\MultiFileUpload\API\Repository\Values\PermissionReport
      */
     public function canUserCreateContent(
-        ContentType $contentType,
         Location $parentLocation,
         UserReference $userReference = null
     ) {
-        $module = 'content';
-        $function = 'create';
-
         if (null !== $userReference) {
             $this->permissionResolver->setCurrentUserReference($userReference);
         }
 
-        $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, $contentType->mainLanguageCode);
         $locationCreateStruct = $this->locationService->newLocationCreateStruct($parentLocation->id);
+        $mappings = $this->getContentTypeIdentifierMappingsForLocation($parentLocation);
+        $allowedContentTypes = [];
 
-        $permissionReport = new PermissionReport([
-            'contentTypeId' => $contentType->id,
-            'parentLocationId' => $parentLocation->id,
-            'module' => $module,
-            'function' => $function,
-            'allowed' => $this->permissionResolver->canUser(
-                $module,
-                $function,
+        foreach ($mappings as $contentTypeIdentifier) {
+            $contentType = $this->contentTypeService->loadContentTypeByIdentifier(
+                $contentTypeIdentifier
+            );
+            $contentCreateStruct = $this->contentService->newContentCreateStruct(
+                $contentType,
+                $contentType->mainLanguageCode
+            );
+            $isAllowed = $this->permissionResolver->canUser(
+                'content',
+                'create',
                 $contentCreateStruct,
                 [$locationCreateStruct]
-            ),
-        ]);
+            );
 
-        return $permissionReport;
+            if ($isAllowed) {
+                $allowedContentTypes[] = $contentTypeIdentifier;
+            }
+        }
+
+        return new PermissionReport([
+            'parentLocationId' => $parentLocation->id,
+            'module' => 'content',
+            'function' => 'create',
+            'allowedContentTypes' => array_unique($allowedContentTypes),
+        ]);
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $parentLocation
+     *
+     * @return array
+     */
+    private function getContentTypeIdentifierMappingsForLocation(Location $parentLocation)
+    {
+        $locationContentType = $this->contentTypeService->loadContentType($parentLocation->getContentInfo()->contentTypeId);
+        $mappings = [];
+
+        foreach ($this->locationMappings as $locationMapping) {
+            if ($locationMapping['content_type_identifier'] === $locationContentType->identifier) {
+                $mappings = $locationMapping['mappings'];
+                break;
+            }
+        }
+
+        $mappings = !empty($mappings)
+            ? $mappings
+            : array_merge($this->defaultMappings, [$this->fallbackContentType]);
+
+        return $this->getUniqueContentTypeIdentifiersFromMappings($mappings);
+    }
+
+    /**
+     * @param array $mappings
+     *
+     * @return array
+     */
+    private function getUniqueContentTypeIdentifiersFromMappings(array $mappings)
+    {
+        return array_unique(array_column($mappings, 'content_type_identifier'));
     }
 }

--- a/tests/bundle/ApplicationConfig/Providers/ContentTypeMappingsTest.php
+++ b/tests/bundle/ApplicationConfig/Providers/ContentTypeMappingsTest.php
@@ -38,7 +38,7 @@ class ContentTypeMappingsTest extends \PHPUnit_Framework_TestCase
                 'mappings' => [
                     [
                         'mime_types' => [
-                            'application/msword'
+                            'application/msword',
                         ],
                         'content_type_identifier' => 'file',
                         'content_field_identifier' => 'file',
@@ -51,7 +51,7 @@ class ContentTypeMappingsTest extends \PHPUnit_Framework_TestCase
             [
                 'mime_types' => [
                     'application/msword',
-                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 ],
                 'content_type_identifier' => 'file',
                 'content_field_identifier' => 'file',

--- a/tests/lib/Core/Repository/PermissionReportServiceTest.php
+++ b/tests/lib/Core/Repository/PermissionReportServiceTest.php
@@ -6,23 +6,25 @@
 namespace EzSystems\MultiFileUpload\Tests\Core\Repository;
 
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\Repository\LocationService;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
-use eZ\Publish\Core\Repository\Values\User\UserReference;
 use EzSystems\MultiFileUpload\API\Repository\Values\PermissionReport;
 use EzSystems\MultiFileUpload\Core\Repository\PermissionReportService;
 
 class PermissionReportServiceTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType */
-    protected $contentType;
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    protected $galleryLocation;
 
     /** @var \eZ\Publish\API\Repository\Values\Content\Location */
-    protected $location;
+    protected $folderLocation;
 
     /** @var \eZ\Publish\API\Repository\PermissionResolver */
     protected $permissionResolver;
@@ -30,16 +32,23 @@ class PermissionReportServiceTest extends \PHPUnit_Framework_TestCase
     /** @var \eZ\Publish\API\Repository\ContentService */
     protected $contentService;
 
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    protected $contentTypeService;
+
     /** @var \eZ\Publish\API\Repository\LocationService */
     protected $locationService;
 
+    /** @var array */
+    protected $locationMappings = [];
+
+    /** @var array */
+    protected $defaultMappings = [];
+
+    /** @var array */
+    protected $fallbackContentType = [];
+
     public function setUp()
     {
-        // Initializing mock objects
-        $contentCreateStruct = $this->getMockBuilder(ContentCreateStruct::class)->getMock();
-        $locationCreateStruct = $this->getMockBuilder(LocationCreateStruct::class)->getMock();
-        $this->contentType = $this->getMockBuilder(ContentType::class)->getMock();
-        $this->location = $this->getMockBuilder(Location::class)->getMock();
         $this->contentService = $this->getMockBuilder(ContentService::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -49,52 +58,211 @@ class PermissionReportServiceTest extends \PHPUnit_Framework_TestCase
         $this->permissionResolver = $this->getMockBuilder(PermissionResolver::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->contentTypeService = $this->getMockBuilder(ContentTypeService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        // Mocking method calls
-        $this->contentType
-            ->expects($this->any())
-            ->method('__get')
-            ->withConsecutive(
-                [$this->equalTo('mainLanguageCode')],
-                [$this->equalTo('id')]
-            )
-            ->willReturnOnConsecutiveCalls(
-                'en-EN',
-                12
-            );
-        $this->location
-            ->method('__get')
-            ->with('id')
-            ->willReturn(30);
-        $this->contentService
-            ->method('newContentCreateStruct')
-            ->with($this->contentType, 'en-EN')
-            ->willReturn($contentCreateStruct);
+        $gallery = $this->getLocationAndContentTypeMocks(51, 31, 'gallery');
+        $folder = $this->getLocationAndContentTypeMocks(52, 32, 'folder');
+
+        $this->galleryLocation = $gallery['location'];
+        $this->folderLocation = $folder['location'];
+
+        $imageContentType = $this->getContentTypeMock();
+        $videoContentType = $this->getContentTypeMock();
+        $fileContentType = $this->getContentTypeMock();
+
+        $imageContentCreateStruct = $this->getMockBuilder(ContentCreateStruct::class)
+            ->getMock();
+        $videoContentCreateStruct = $this->getMockBuilder(ContentCreateStruct::class)
+            ->getMock();
+        $fileContentCreateStruct = $this->getMockBuilder(ContentCreateStruct::class)
+            ->getMock();
+
+        $this->contentTypeService
+            ->method('loadContentType')
+            ->willReturnMap([
+                [31, $gallery['contentType']],
+                [32, $folder['contentType']],
+            ]);
+
         $this->locationService
             ->method('newLocationCreateStruct')
-            ->with(30)
-            ->willReturn($locationCreateStruct);
+            ->willReturnMap([
+                [51, $gallery['locationCreateStruct']],
+                [52, $folder['locationCreateStruct']],
+            ]);
+
+        $this->contentTypeService
+            ->method('loadContentTypeByIdentifier')
+            ->willReturnMap([
+                ['image', $imageContentType],
+                ['video', $videoContentType],
+                ['file', $fileContentType],
+            ]);
+
+        $this->contentService
+            ->method('newContentCreateStruct')
+            ->willReturnMap([
+                [$imageContentType, 'en-EN', $imageContentCreateStruct],
+                [$videoContentType, 'en-EN', $videoContentCreateStruct],
+                [$fileContentType, 'en-EN', $fileContentCreateStruct],
+            ]);
+
         $this->permissionResolver
             ->method('canUser')
-            ->with('content', 'create', $contentCreateStruct, [$locationCreateStruct])
-            ->willReturn(true);
+            ->willReturnMap([
+                [
+                    'content',
+                    'create',
+                    $imageContentCreateStruct,
+                    [$gallery['locationCreateStruct']],
+                    true,
+                ],
+                [
+                    'content',
+                    'create',
+                    $videoContentCreateStruct,
+                    [$gallery['locationCreateStruct']],
+                    false,
+                ],
+                [
+                    'content',
+                    'create',
+                    $fileContentCreateStruct,
+                    [$gallery['locationCreateStruct']],
+                    true,
+                ],
+                [
+                    'content',
+                    'create',
+                    $imageContentCreateStruct,
+                    [$folder['locationCreateStruct']],
+                    true,
+                ],
+                [
+                    'content',
+                    'create',
+                    $videoContentCreateStruct,
+                    [$folder['locationCreateStruct']],
+                    false,
+                ],
+                [
+                    'content',
+                    'create',
+                    $fileContentCreateStruct,
+                    [$folder['locationCreateStruct']],
+                    true,
+                ],
+            ]);
+
+        $this->locationMappings = [
+            [
+                'content_type_identifier' => 'gallery',
+                'mime_type_filter' => [
+                    'video/*',
+                    'image/*',
+                ],
+                'mappings' => [
+                    [
+                        'mime_types' => [
+                            'image/jpeg',
+                            'image/jpg',
+                            'image/pjpeg',
+                            'image/pjpg',
+                            'image/png',
+                            'image/bmp',
+                            'image/gif',
+                            'image/tiff',
+                            'image/x-icon',
+                            'image/webp',
+                        ],
+                        'content_type_identifier' => 'image',
+                        'content_field_identifier' => 'image',
+                        'name_field_identifier' => 'name',
+                    ],
+                    [
+                        'mime_types' => [
+                            'video/avi',
+                            'video/mpeg',
+                            'video/quicktime',
+                            'video/mp4',
+                            'video/webm',
+                            'video/3gpp',
+                            'video/x-msvideo',
+                            'video/ogg',
+                        ],
+                        'content_type_identifier' => 'video',
+                        'content_field_identifier' => 'file',
+                        'name_field_identifier' => 'name',
+                    ],
+                ],
+            ],
+        ];
+        $this->defaultMappings = [
+            [
+                'mime_types' => [
+                    'image/svg+xml',
+                    'application/msword',
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    'application/vnd.ms-excel',
+                    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    'application/vnd.ms-powerpoint',
+                    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                    'application/pdf',
+                ],
+                'content_type_identifier' => 'file',
+                'content_field_identifier' => 'file',
+                'name_field_identifier' => 'name',
+            ],
+        ];
+        $this->fallbackContentType = [
+            'content_type_identifier' => 'file',
+            'content_field_identifier' => 'file',
+            'name_field_identifier' => 'name',
+        ];
     }
 
-    public function testCanUserCreateContent()
+    public function testCanUserCreateContentUsingLocationMapping()
     {
         $permissionReportService = new PermissionReportService(
             $this->permissionResolver,
             $this->contentService,
-            $this->locationService
+            $this->contentTypeService,
+            $this->locationService,
+            $this->locationMappings,
+            $this->defaultMappings,
+            $this->fallbackContentType
         );
-        $permissionReport = $permissionReportService->canUserCreateContent($this->contentType, $this->location);
+
+        $permissionReport = $permissionReportService->canUserCreateContent($this->galleryLocation);
 
         $this->assertInstanceOf(PermissionReport::class, $permissionReport);
-        $this->assertEquals('12', $permissionReport->contentTypeId);
-        $this->assertEquals('30', $permissionReport->parentLocationId);
+        $this->assertEquals('51', $permissionReport->parentLocationId);
         $this->assertEquals('content', $permissionReport->module);
         $this->assertEquals('create', $permissionReport->function);
-        $this->assertTrue($permissionReport->allowed);
+        $this->assertEquals(['image'], $permissionReport->allowedContentTypes);
+    }
+
+    public function testCanUserCreateContentUsingDefaultAndFallbackMappings()
+    {
+        $permissionReportService = new PermissionReportService(
+            $this->permissionResolver,
+            $this->contentService,
+            $this->contentTypeService,
+            $this->locationService,
+            $this->locationMappings,
+            $this->defaultMappings,
+            $this->fallbackContentType
+        );
+
+        $permissionReport = $permissionReportService->canUserCreateContent($this->folderLocation);
+
+        $this->assertInstanceOf(PermissionReport::class, $permissionReport);
+        $this->assertEquals('52', $permissionReport->parentLocationId);
+        $this->assertEquals('content', $permissionReport->module);
+        $this->assertEquals('create', $permissionReport->function);
+        $this->assertEquals(['file'], $permissionReport->allowedContentTypes);
     }
 
     public function testCanUserCreateContentWithInjectedUser()
@@ -111,19 +279,79 @@ class PermissionReportServiceTest extends \PHPUnit_Framework_TestCase
         $permissionReportService = new PermissionReportService(
             $this->permissionResolver,
             $this->contentService,
-            $this->locationService
+            $this->contentTypeService,
+            $this->locationService,
+            $this->locationMappings,
+            $this->defaultMappings,
+            $this->fallbackContentType
         );
+
         $permissionReport = $permissionReportService->canUserCreateContent(
-            $this->contentType,
-            $this->location,
+            $this->galleryLocation,
             $userReference
         );
 
         $this->assertInstanceOf(PermissionReport::class, $permissionReport);
-        $this->assertEquals('12', $permissionReport->contentTypeId);
-        $this->assertEquals('30', $permissionReport->parentLocationId);
+        $this->assertEquals('51', $permissionReport->parentLocationId);
         $this->assertEquals('content', $permissionReport->module);
         $this->assertEquals('create', $permissionReport->function);
-        $this->assertTrue($permissionReport->allowed);
+        $this->assertEquals(['image'], $permissionReport->allowedContentTypes);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getContentTypeMock()
+    {
+        $fileContentType = $this->getMockBuilder(ContentType::class)
+            ->getMock();
+        $fileContentType->method('__get')
+            ->willReturnMap([
+                ['mainLanguageCode', 'en-EN'],
+            ]);
+
+        return $fileContentType;
+    }
+
+    /**
+     * @param int $locationId
+     * @param int $contentTypeId
+     * @param string $contentTypeIdentifier
+     *
+     * @return array
+     */
+    private function getLocationAndContentTypeMocks($locationId, $contentTypeId, $contentTypeIdentifier)
+    {
+        $locationCreateStruct = $this->getMockBuilder(LocationCreateStruct::class)
+            ->getMock();
+        $location = $this->getMockBuilder(Location::class)
+            ->getMock();
+        $locationContentType = $this->getMockBuilder(ContentType::class)
+            ->getMock();
+        $locationContentInfo = $this->getMockBuilder(ContentInfo::class)
+            ->getMock();
+
+        $location
+            ->method('getContentInfo')
+            ->willReturn($locationContentInfo);
+        $locationContentType
+            ->method('__get')
+            ->with('identifier')
+            ->willReturn($contentTypeIdentifier);
+        $locationContentInfo
+            ->method('__get')
+            ->with('contentTypeId')
+            ->willReturn($contentTypeId);
+        $location
+            ->method('__get')
+            ->with('id')
+            ->willReturn($locationId);
+
+        return [
+            'location' => $location,
+            'contentType' => $locationContentType,
+            'contentInfo' => $locationContentInfo,
+            'locationCreateStruct' => $locationCreateStruct,
+        ];
     }
 }


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-27439

**Description**
The goal is to limit request on permissions check. In the old way, we sent 4 requests for every content type in configuration list. For example, if `gallery` has allowed content types `image` and `video` we sent 8 requests to check permissions. Now we limit it to the one request, no matter how many content types we have to check.

**TO DO**
- [x] avoid duplicated requests - the `UploadFormView` in the popup also check the permissions, in this solution we do not check it as if user is in this step he can create content in the location
- [x] avoid sending a request for content type and then for permission check - now we send one request to check permissions in the specific location.
- [x] unit tests