### PR TITLE
EZP-28161: Update php-cs-fixer configuration to align with v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_annotation_without_dot' => false,
         'phpdoc_no_alias_tag' => false,
         'space_after_semicolon' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+
+php:
+    - 7.1
+
+# test only master and stable branches (+ Pull requests)
+branches:
+    only:
+        - master
+        - /^\d.\d+$/
+
+install:
+    # Disable XDebug for better performance
+    - phpenv config-rm xdebug.ini
+    # Avoid memory issues on composer install
+    - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    # Get latest composer build
+    - travis_retry composer selfupdate
+    # Install packages
+    - travis_retry composer install --prefer-dist --no-interaction
+
+script:
+    - vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating
+
+notifications:
+    email: false

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
-        "friendsofphp/php-cs-fixer": "^2.1"
+        "friendsofphp/php-cs-fixer": "~2.7.1"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "phpunit/phpunit": "~4.7",
         "friendsofphp/php-cs-fixer": "~2.7.1"
     },
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.1.x-dev"


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161)

This PR updates `.php_cs` config to be compatible with `v2.7.1`.

To simplify fixing code it also adds dev dependency on `php-cs-fixer` and introduces composer command:
```
composer fix-cs
```
which runs fixer on all files.

**TODO**:
- [x] Update php-cs-fixer config (`.php_cs`)
- [x] Add `php-cs-fixer` dev dependency to composer pointing to `~2.7.1`
- [x] Add composer command `fix-cs`