### PR TITLE
Enhance PermissionReport with parent location for cache usage

### DIFF
--- a/lib/API/Repository/Values/PermissionReport.php
+++ b/lib/API/Repository/Values/PermissionReport.php
@@ -9,6 +9,9 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 
 class PermissionReport extends ValueObject
 {
+    /** @var \eZ\Publish\API\Repository\Values\Content\Location */
+    public $parentLocation;
+
     /** @var int */
     public $parentLocationId;
 

--- a/lib/Core/Repository/PermissionReportService.php
+++ b/lib/Core/Repository/PermissionReportService.php
@@ -106,6 +106,7 @@ class PermissionReportService implements PermissionReportServiceInterface
         }
 
         return new PermissionReport([
+            'parentLocation' => $parentLocation,
             'parentLocationId' => $parentLocation->id,
             'module' => 'content',
             'function' => 'create',


### PR DESCRIPTION
> Used by: https://github.com/ezsystems/ezplatform-http-cache/pull/59

Small change in order to be be able to tag and cache the REST response from this package in order to speed up 1.x Platform UI as reported by misc customers as a problem they are about to face big time once they start to take it activly in use for larger editor teams. So smaller changes here in order to avoid uncached GET request to REST API.